### PR TITLE
fix: $type为radio时，value为0时会变成undefined

### DIFF
--- a/src/mixin-package-option.js
+++ b/src/mixin-package-option.js
@@ -1,41 +1,53 @@
 /**
  * 扩展表单组件的 option 属性
  */
-function controller (h, tag, props) {
+function controller(h, tag, props) {
   return h(tag, {
     props
   })
 }
 
-function controllerVariation (h, tag, props) {
-  return h(tag, {
-    props: Object.assign({}, props, {
-      key: props.value || props.label,
-      label: props.value || props.label
-    })
-  }, props.label)
+function resolveValue({value, label}) {
+  return value !== undefined && value !== null ? value : label
+}
+
+function controllerVariation(h, tag, props) {
+  return h(
+    tag,
+    {
+      props: Object.assign({}, props, {
+        key: resolveValue(props),
+        label: resolveValue(props)
+      })
+    },
+    props.label
+  )
 }
 
 export default {
   methods: {
-    select_opt (item) {
+    select_opt(item) {
       return controller(this.$createElement, 'el-option', item)
     },
 
-    radioGroup_opt (item) {
+    radioGroup_opt(item) {
       return controllerVariation(this.$createElement, 'el-radio', item)
     },
 
-    radioButton_opt (item) {
+    radioButton_opt(item) {
       return controllerVariation(this.$createElement, 'el-radio-button', item)
     },
 
-    checkboxGroup_opt (item) {
+    checkboxGroup_opt(item) {
       return controllerVariation(this.$createElement, 'el-checkbox', item)
     },
 
-    checkboxButton_opt (item) {
-      return controllerVariation(this.$createElement, 'el-checkbox-button', item)
+    checkboxButton_opt(item) {
+      return controllerVariation(
+        this.$createElement,
+        'el-checkbox-button',
+        item
+      )
     }
   }
 }


### PR DESCRIPTION
fix #26

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

情况

当`$type`为`{radio,radio-button,checkbox,checkbox-button}-group`时
设置`value`为`0`并且不设置`label`的时候,会转至`undefined`

```js
$options: {
  value: 0
}
```
