### PR TITLE
docs(el): 补充自定义组件传props示例

### DIFF
--- a/docs/el.md
+++ b/docs/el.md
@@ -1,0 +1,30 @@
+
+可以对自定义组件传入 `props`，使用 `el` 传入
+
+例如配合 `upload-to-ali`，控制上传文件类型
+
+```vue
+<template>
+  <el-form-renderer :content="content" inline />
+</template>
+
+<script>
+export default {
+  name: 'el',
+  data() {
+    return {
+      content: [
+        {
+          id: 'document',
+          // 全局注册的第三方组件
+          component: 'upload-to-ali',
+          el: {
+            accept: 'application/pdf'  // 限定 upload-to-ali 只允许 pdf 文件
+          }
+        }
+      ]
+    }
+  }
+}
+</script>
+```


### PR DESCRIPTION
## Why
文档缺少对自定义组件传入参数做出描述，对用户使用造成不便

## How
添加`el.md`，对`el`与自定义组件配合使用做出描述

## Test
### after
![image](https://user-images.githubusercontent.com/21327913/60637812-80f9c100-9e4e-11e9-9292-3bbb510339f1.png)

