### PR TITLE
docs: 修复代码展示

### DIFF
--- a/docs/guide-custom-rules-in-custom-component.md
+++ b/docs/guide-custom-rules-in-custom-component.md
@@ -70,7 +70,7 @@ export default {
 
 `rules` 也可以是个函数, 参数是当前表单项配置, 需要返回一个数组.
 
-```js
+```bash
 rules(item) {
   return [
     {


### PR DESCRIPTION
## Why

使用`bash`代替`js`,因为他只是为了展示代码段

vue-styleguidist 竟然把他跑起来了!

## Docs

- guide-custom-rules-in-custom-component.md