### PR TITLE
fix: 修复 input 框不能输入空格的问题

### DIFF
--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -83,18 +83,21 @@ export default {
             }, {}),
             // 手动更新表单数据
             input: (value, ...rest) => {
-              // 默认字符串类型处理去空格
+              this.$emit('updateValue', {id: data.id, value: value})
+              // 更新表单时调用
+              if (typeof data.atChange === 'function') {
+                data.atChange(data.id, value)
+              }
+              if (on.input) on.input([value, ...rest], updateForm)
+            },
+            change: (value, ...rest) => {
               const trimVal =
                 typeof value === 'string' &&
                 (data.trim === undefined || data.trim)
                   ? value.trim()
                   : value
               this.$emit('updateValue', {id: data.id, value: trimVal})
-              // 更新表单时调用
-              if (typeof data.atChange === 'function') {
-                data.atChange(data.id, trimVal)
-              }
-              if (on.input) on.input([trimVal, ...rest], updateForm)
+              if (on.change) on.change([trimVal, ...rest], updateForm)
             }
           }
         },


### PR DESCRIPTION
把 trim 处理时机改在 input 的 change 事件，修复 input 框不能输入空格的问题

使用时在 on 里监听 change 能够正常执行，因为源码中已对此做了处理（说明如下）
on 是对象，源码里的 change 事件会覆盖掉传入的 change，所以要调用一次用户绑定的 change 事件处理函数（红框处），这样传入的 change 事件处理函数也能执行
![9A83D195-F82F-45c0-AEB5-F33ECB2CC894](https://user-images.githubusercontent.com/26338853/61855206-3d94ee80-aef2-11e9-99e0-59eebd1783ee.png)


## Why
默认情况下 (trim 为 true)，input 框不能输入空格

## How
1. input 事件中不处理输入值
2. change 事件中才使用 trim 处理输入值首尾空格

![form-renderer](https://user-images.githubusercontent.com/26338853/61760215-69827800-adfd-11e9-8f02-23de9d1d9d15.jpg)

## Test
1. el-input 能够输入空格，触发 change 事件时能够去掉输入值首尾空格
2. 使用时在 on 里监听 change 能够正常执行

- BEFORE
![a](https://user-images.githubusercontent.com/26338853/61855724-315d6100-aef3-11e9-8aa0-555d7e859c78.gif)


- AFTER
![GIF](https://user-images.githubusercontent.com/26338853/61686507-641c2380-ad52-11e9-973f-3c8181786dec.gif)
