### PR TITLE
feat: 可以覆盖自定义组件内部的校验规则

### DIFF
--- a/docs/guide-custom-rules-in-custom-component.md
+++ b/docs/guide-custom-rules-in-custom-component.md
@@ -97,8 +97,15 @@ export default {
         {
           id: 'phone',
           label: 'phone',
+          component: YourComponent,
           overrideRules: true,
-          component: YourComponent
+          rules: [
+            {
+              required: true,
+              trigger: 'blur',
+              message: '不能为空！'
+            }
+          ]
         }
       ]
     }

--- a/docs/guide-custom-rules-in-custom-component.md
+++ b/docs/guide-custom-rules-in-custom-component.md
@@ -81,7 +81,7 @@ rules(item) {
 }
 ```
 
-如果需要覆盖自定义组件内置的校验规则则可以通过 `overrideRules: true` 来覆盖
+可以通过 `overrideRules: true` 来覆盖自定义组件内置的校验规则
 
 ```html
 <template>

--- a/docs/guide-custom-rules-in-custom-component.md
+++ b/docs/guide-custom-rules-in-custom-component.md
@@ -81,6 +81,32 @@ rules(item) {
 }
 ```
 
+如果需要覆盖自定义组件内置的校验规则则可以通过 `overrideRules: true` 来覆盖
+
+```html
+<template>
+  <el-form-renderer ref="form" :content="content"></el-form-renderer>
+</template>
+
+<script>
+import YourComponent from './your-component.vue'
+export default {
+  data() {
+    return {
+      content: [
+        {
+          id: 'phone',
+          label: 'phone',
+          overrideRules: true,
+          component: YourComponent
+        }
+      ]
+    }
+  }
+}
+</script>
+```
+
 ## 在线Demo
 
 [点击查看](https://rules-component.fem-misc.now.sh/#/misc)

--- a/docs/guide-en-custom-rules-in-custom-component.md
+++ b/docs/guide-en-custom-rules-in-custom-component.md
@@ -71,7 +71,7 @@ rules(item) {
 }
 ```
 
-If you need to override the validation rules built into the custom component, you can override it with `overrideRules: true`
+If you need to override the validation rules written in custom component, you can override it with `overrideRules: true`
 
 ```html
 <template>

--- a/docs/guide-en-custom-rules-in-custom-component.md
+++ b/docs/guide-en-custom-rules-in-custom-component.md
@@ -71,7 +71,7 @@ rules(item) {
 }
 ```
 
-If you need to override the validation rules written in custom component, just set `overrideRules: true`
+Set `overrideRules: true` to override the validation rules written in custom component
 
 ```html
 <template>

--- a/docs/guide-en-custom-rules-in-custom-component.md
+++ b/docs/guide-en-custom-rules-in-custom-component.md
@@ -71,7 +71,7 @@ rules(item) {
 }
 ```
 
-If you need to override the validation rules written in custom component, you can override it with `overrideRules: true`
+If you need to override the validation rules written in custom component, just set `overrideRules: true`
 
 ```html
 <template>

--- a/docs/guide-en-custom-rules-in-custom-component.md
+++ b/docs/guide-en-custom-rules-in-custom-component.md
@@ -71,6 +71,32 @@ rules(item) {
 }
 ```
 
+If you need to override the validation rules built into the custom component, you can override it with `overrideRules: true`
+
+```html
+<template>
+  <el-form-renderer ref="form" :content="content"></el-form-renderer>
+</template>
+
+<script>
+import YourComponent from './your-component.vue'
+export default {
+  data() {
+    return {
+      content: [
+        {
+          id: 'phone',
+          label: 'phone',
+          overrideRules: true,
+          component: YourComponent
+        }
+      ]
+    }
+  }
+}
+</script>
+```
+
 ## Live Demo
 
 [Checkout live demo](https://rules-component.fem-misc.now.sh/#/misc)

--- a/docs/guide-en-custom-rules-in-custom-component.md
+++ b/docs/guide-en-custom-rules-in-custom-component.md
@@ -87,8 +87,15 @@ export default {
         {
           id: 'phone',
           label: 'phone',
+          component: YourComponent,
           overrideRules: true,
-          component: YourComponent
+          rules: [
+            {
+              required: true,
+              trigger: 'blur',
+              message: 'Can not empty!'
+            }
+          ]
         }
       ]
     }

--- a/src/custom-component-rules.js
+++ b/src/custom-component-rules.js
@@ -8,7 +8,7 @@ export default function(content) {
 
   const {rules = []} = content
 
-  if (component.rules) {
+  if (component.rules && content.overrideRules !== true) {
     typeof component.rules === 'function'
       ? rules.push(...component.rules(content))
       : rules.push(...component.rules)

--- a/src/el-form-renderer.md
+++ b/src/el-form-renderer.md
@@ -91,6 +91,14 @@ interface Content {
    */
   component?: Vue
 
+  /**
+   * 是否覆盖或关闭自定义组件内置的校验规则
+   * `true` 为覆盖或关闭， 否则堆叠
+   * whether to override or disable the verification rules built into custom components
+   * `true` to override or disable, stack otherwise
+   */
+  overrideRules: boolean
+
   label?: string //set el-form-item's label
   trim = true // trim value at change event
 

--- a/src/el-form-renderer.md
+++ b/src/el-form-renderer.md
@@ -92,10 +92,10 @@ interface Content {
   component?: Vue
 
   /**
-   * 是否覆盖或关闭自定义组件内置的校验规则
-   * `true` 为覆盖或关闭， 否则堆叠
-   * whether to override or disable the verification rules built into custom components
-   * `true` to override or disable, stack otherwise
+   * 是否覆盖自定义组件内置的校验规则
+   * `true` 为覆盖， 否则堆叠
+   * whether to override the verification rules built into custom components
+   * `true` to override, stack otherwise
    */
   overrideRules: boolean
 

--- a/src/el-form-renderer.md
+++ b/src/el-form-renderer.md
@@ -93,9 +93,9 @@ interface Content {
 
   /**
    * 是否覆盖自定义组件内置的校验规则
-   * `true` 为覆盖， 否则堆叠
-   * whether to override the verification rules built into custom components
-   * `true` to override, stack otherwise
+   * `true` 为覆盖， 默认为 `false`
+   * whether to override the validation rules written in custom components
+   * `true` to override, default `false`
    */
   overrideRules: boolean
 


### PR DESCRIPTION
## Why

自定义组件内部的校验规则并非强制使用

## How

```js
{
  // 覆盖
  overrideRules: true
}
```

## Test

```console
$ jest
 PASS  test/custom-component-rules.test.js
 PASS  test/transform-content.test.js
 PASS  test/mixin-hidden.test.js (5.304s)
 PASS  test/set-options.test.js
 PASS  test/init-item-options.test.js
 PASS  test/reset-fields.test.js

Test Suites: 6 passed, 6 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        9.535s
Ran all test suites.
```

## Docs

- `src/el-form-renderer.md`
- `docs/guide-custom-rules-in-custom-component.md`
- `docs/guide-en-custom-rules-in-custom-component.md`