### PR TITLE
fix: 当 type=group 时，options 报 undefined

### DIFF
--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -70,6 +70,7 @@ export default {
   },
   beforeMount() {
     this._content = transformContent(this.content)
+    this.initItemOption()
     this._content.forEach(this.initItemValue)
   },
   mounted() {
@@ -93,8 +94,6 @@ export default {
         })
       }
     })
-
-    this.initItemOption()
   },
   props: Object.assign({}, Form.props, {
     content: {


### PR DESCRIPTION
close #95

## Why

在初始化值的时候，group 还未有精确的子表单项的 options 导致。

解决控制台报错

## How

1. 移动初始化 options 到初始化 value 之前

## Test

![image](https://user-images.githubusercontent.com/53422750/62863158-9d84f500-bd3a-11e9-9bd7-bf3a13b0d255.png)


```js
content: [
  {
    id: 'group',
    type: 'group',
    items: [
      {
        id: 'select',
        type: 'select',
        label: 'select',
        options: [{value: 2}]
      },
      {
        id: 'name1',
        type: 'input',
        label: 'name1'
      }
    ]
  },
  {
    id: 'select1',
    type: 'select',
    label: 'select1',
    options: [{value: 1}]
  }
]
```

```console
$ jest --verbose
 PASS  test/custom-component-rules.test.js
  自定义组件规则
    ✓ 调用函数返回规则 (62ms)
    ✓ 获取静态规则 (2ms)

 PASS  test/transform-content.test.js
  ✓ transform content (25ms)

 PASS  test/mixin-hidden.test.js
  mixin-hidden.js
    enableWhen 与 hidden
      ✓ 没有使用 enableWhen 与 hidden (21ms)
      ✓ 使用 enableWhen，不被 hidden 干扰 (6ms)
      ✓ 同时使用 hidden 与 enableWhen，仅响应 hidden (3ms)
    使用 hidden
      ✓ 使用 hidden，返回 true，不显示 (2ms)
      ✓ 使用 hidden，返回 false，显示 (1ms)
    hidden 可以使用 form 与当前 item 值
      ✓ hidden 可以获取 form 值 (2ms)
      ✓ hidden 可以获取 item 信息 (2ms)

 PASS  test/set-options.test.js
  ✓ set options (3ms)

 PASS  test/init-item-options.test.js
  ✓ initial item options (7ms)

 PASS  test/reset-fields.test.js
  测试 ElFormRenderer 的 resetFields 函数
    ✓ 传入有 undefined 值的数组应返回去除 undefined 的数组 (3ms)

Test Suites: 6 passed, 6 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        8.377s
Ran all test suites.
```

