### PR TITLE
fix: `inputFormat` 允许返回任何类型

### DIFF
--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -212,12 +212,14 @@ export default {
     updateForm(values) {
       const updateValue = content => {
         return content.reduce((acc, item) => {
-          const value =
-            item.type === GROUP
-              ? updateValue(item.items)
-              : typeof item.inputFormat === 'function'
+          let value
+          if (item.type === GROUP) {
+            value = updateValue(item.items)
+          } else {
+            value = typeof item.inputFormat === 'function'
               ? item.inputFormat(values)
               : values[id]
+          }
 
           if (value !== undefined) {
             _set(acc, item.id, value)

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -215,8 +215,9 @@ export default {
           const value =
             item.type === GROUP
               ? updateValue(item.items)
-              : (item.inputFormat && item.inputFormat(values)) ||
-                values[item.id]
+              : typeof item.inputFormat === 'function'
+              ? item.inputFormat(values)
+              : values[id]
 
           if (value !== undefined) {
             _set(acc, item.id, value)


### PR DESCRIPTION
fix #94

## Why

作为表单项，表单项的值应该允许接收任何类型，保持表单一致。

## How

1. 变更 `inputFormat` 判断条件，允许使用者的 `formatter` 返回任何类型。
2. 根据 formatter api，`inputFormat` 只允许函数。

```diff
- const value =
-  item.type === GROUP
-    ? updateValue(item.items)
-    : (item.inputFormat && item.inputFormat(values)) ||
-      values[item.id]

+ let value
+ if (item.type === GROUP) {
+   value = updateValue(item.items)
+ } else {
+   value = typeof item.inputFormat === 'function'
+     ? item.inputFormat(values)
+     : values[id]
+ }
```

## Test

```console
$ jest --verbose
 PASS  test/custom-component-rules.test.js
  自定义组件规则
    ✓ 调用函数返回规则 (21ms)
    ✓ 获取静态规则 (2ms)

 PASS  test/transform-content.test.js
  ✓ transform content (22ms)

 PASS  test/mixin-hidden.test.js
  mixin-hidden.js
    enableWhen 与 hidden
      ✓ 没有使用 enableWhen 与 hidden (63ms)
      ✓ 使用 enableWhen，不被 hidden 干扰 (4ms)
      ✓ 同时使用 hidden 与 enableWhen，仅响应 hidden (3ms)
    使用 hidden
      ✓ 使用 hidden，返回 true，不显示 (1ms)
      ✓ 使用 hidden，返回 false，显示 (2ms)
    hidden 可以使用 form 与当前 item 值
      ✓ hidden 可以获取 form 值 (2ms)
      ✓ hidden 可以获取 item 信息 (3ms)

 PASS  test/init-item-options.test.js
  ✓ initial item options (11ms)

 PASS  test/set-options.test.js
  ✓ set options (3ms)

 PASS  test/reset-fields.test.js
  测试 ElFormRenderer 的 resetFields 函数
    ✓ 传入有 undefined 值的数组应返回去除 undefined 的数组 (3ms)

Test Suites: 6 passed, 6 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        7.987s
Ran all test suites.
```
