### PR TITLE
fix(hack): 表单项值变更时清除校验信息

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,4 +1,6 @@
-## 验证规则问题
+## 即时校验
+
+> 改变值后立马触发校验规则的 trigger 是 `change`, 并不是 `blur`.
 
 类输入框表单组件(例如: select, **cascader**)不会触发 trigger 为 'blur' 的那条校验规则.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@ rules: [
 ]
 ```
 
-对于这类表单组件的规则应该这样设置(变更为 change 或者不设置 trigger):
+对于这类表单组件的规则应该这样设置(trigger 变更为 change 或者不设置 trigger):
 
 ```diff
  rules: [

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,26 @@
+## 验证规则问题
+
+类输入框表单组件(例如: select, **cascader**)不会触发 trigger 为 'blur' 的那条校验规则.
+
+例如以下这条规则:
+
+```bash
+rules: [
+  {
+    message: '校验提示信息',
+    trigger: 'blur'
+  }
+]
+```
+
+对于这类表单组件的规则应该这样设置(变更为 change 或者不设置 trigger):
+
+```diff
+ rules: [
+   {
+     message: '校验提示信息',
+-    trigger: 'blur'
++    trigger: 'change'
+   }
+ ]
+```

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -15,7 +15,7 @@ rules: [
 ]
 ```
 
-对于这类表单组件的规则应该这样设置(trigger 变更为 change 或者不设置 trigger):
+为了能够使得表单项即时校验应该这样设置(trigger 变更为 change 或者不设置 trigger):
 
 ```diff
  rules: [

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -15,7 +15,7 @@ rules: [
 ]
 ```
 
-为了能够使得表单项即时校验应该这样设置(trigger 变更为 change 或者不设置 trigger):
+如果想即时校验，则应该这样设置(trigger 变更为 change 或者不设置 trigger):
 
 ```diff
  rules: [

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -126,6 +126,8 @@ export default {
     },
 
     triggerValidate(id) {
+      if (!this.data.rules || !this.data.rules.length) return
+
       let parent = this.$parent
       let name = parent.$options._componentTag
 

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -129,13 +129,13 @@ export default {
       if (!this.data.rules || !this.data.rules.length) return
 
       let parent = this.$parent
-      let name = parent.$options._componentTag
+      let name = parent.$options.componentName
 
-      while (parent && name !== 'el-form') {
+      while (parent && name !== 'ElForm') {
         parent = parent.$parent
 
         if (parent) {
-          name = parent.$options._componentTag
+          name = parent.$options.componentName
         }
       }
 

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -130,6 +130,8 @@ export default {
 
       /**
        * 下面代码可参考 `emitter`
+       * 目的: 为了清除表单校验信息
+       * 因为有部分表单项的值变更时没有清除校验信息, 因此需要触发一次校验用于清除
        * https://github.com/ElemeFE/element/blob/dev/src/mixins/emitter.js
        */
       let parent = this.$parent

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -28,6 +28,15 @@ export default {
     disabled: Boolean,
     options: Array
   },
+  data() {
+    return {
+      isBlurTrigger:
+        this.data.rules &&
+        this.data.rules.some(rule => {
+          return rule.required && rule.trigger === 'blur'
+        })
+    }
+  },
   computed: {
     // 是否显示
     _show() {
@@ -86,6 +95,8 @@ export default {
                 data.atChange(data.id, value)
               }
               if (on.input) on.input([value, ...rest], updateForm)
+
+              this.triggerValidate(data.id)
             },
             change: (value, ...rest) => {
               const trimVal =
@@ -95,6 +106,8 @@ export default {
                   : value
               this.$emit('updateValue', {id: data.id, value: trimVal})
               if (on.change) on.change([trimVal, ...rest], updateForm)
+
+              this.triggerValidate(data.id)
             }
           }
         },
@@ -110,6 +123,25 @@ export default {
           })()
         ]
       )
+    },
+
+    triggerValidate(id) {
+      let parent = this.$parent
+      let name = parent.$options._componentTag
+
+      while (parent && (!name || name !== 'el-form')) {
+        parent = parent.$parent
+
+        if (parent) {
+          name = parent.$options._componentTag
+        }
+      }
+
+      if (!parent || this.isBlurTrigger) return
+
+      this.$nextTick(() => {
+        parent.validateField(id)
+      })
     }
   }
 }

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -128,6 +128,10 @@ export default {
     triggerValidate(id) {
       if (!this.data.rules || !this.data.rules.length) return
 
+      /**
+       * 下面代码可参考 `emitter`
+       * https://github.com/ElemeFE/element/blob/dev/src/mixins/emitter.js
+       */
       let parent = this.$parent
       let name = parent.$options.componentName
 

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -131,7 +131,7 @@ export default {
       let parent = this.$parent
       let name = parent.$options._componentTag
 
-      while (parent && (!name || name !== 'el-form')) {
+      while (parent && name !== 'el-form') {
         parent = parent.$parent
 
         if (parent) {


### PR DESCRIPTION
close #84

## Why

- 部分表单项输入时无法清除校验信息, 导致体验稍差, 例如:
  - El Cascader
  - [Upload To Ali](https://github.com/FEMessage/upload-to-ali)

## How

在当前表单值变更的时候手动触发一次验证.

只有这个表单项设置了规则(rules)并且 trigger 不为 `blur` , 才会进行这个校验操作.

## Test

> 检验表单值变更时校验信息是否像**预期**一样清除

### 正常的表单项

- [x] el-cascader
- [x] el-input
- [x] el-checkbox
- [x] ...

![check-rules-trigger-common](https://user-images.githubusercontent.com/53422750/65501278-4a828e00-def3-11e9-89fe-48ea1b10f167.gif)

### Upload To Ali(自定义组件)

![check-rules-trigger](https://user-images.githubusercontent.com/53422750/65500202-84eb2b80-def1-11e9-821b-7e2e77d31e0e.gif)

### 自定义组件(完全自定义组件)

```html
<input :value="value" @input="e => $emit('input', e.target.value)" >
```

![check-rules-trigger-custom-comp](https://user-images.githubusercontent.com/53422750/65500371-cb408a80-def1-11e9-8cf3-3d202d7e6db4.gif)

### 其他函数

```console
Test Suites: 6 passed, 6 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        9.244s
```

## 另外想到其他的操作方式

### elFormItem.dispatch(未果)

在 `@input` 或者 `@change` 阶段触发 elFormItem.dispatch, 手动通知 el-form 这个表单项有变更.

## 另外另外的问题

1. 只要套一层组件去包装 FormItem 和 表单项, 以上几个就会出现此情况.

## Docs

- faq.md 用于解释规则应该如何正确的设置