### PR TITLE
fix: 解决`File` 对象丢失的问题

### DIFF
--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -5,25 +5,6 @@ import RenderFormItem from './render-form-item'
 import transformContent from './transform-content'
 import {isObject} from './utils'
 
-// 拷贝简单数据
-//    不考虑引用，函数等复杂数据
-function clone(data) {
-  if (Array.isArray(data)) {
-    return data.map(clone)
-  } else if (data && typeof data === 'object') {
-    let obj = Object.assign({}, data)
-    for (let key in obj) {
-      if (!obj.hasOwnProperty(key)) continue
-      if (typeof obj[key] === 'object') {
-        obj[key] = clone(obj[key])
-      }
-    }
-    return obj
-  } else {
-    return data
-  }
-}
-
 const GROUP = 'group'
 
 export default {
@@ -188,20 +169,20 @@ export default {
             acc[key] = getValue(values[key], item.items)
           } else {
             if (item.outputFormat) {
-              const formatVal = item.outputFormat(clone(values[key]))
+              const formatVal = item.outputFormat(values[key])
               // 如果 outputFormat 返回的是一个对象，则合并该对象，否则在原有 acc 上新增该 属性：值
               isObject(formatVal)
                 ? Object.assign(acc, formatVal)
                 : (acc[key] = formatVal)
             } else {
-              acc[key] = clone(values[key])
+              acc[key] = values[key]
             }
           }
 
           return acc
         }, {})
       }
-      return getValue(this.value, this._content)
+      return {...getValue(this.value, this._content)}
     },
     /**
      * update form values


### PR DESCRIPTION
close #106


<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why

- 使用者使用 el-upload 封装了自定义组件, `emit` 选择的文件后, 无法获取预期的结果.

## How

1. 删除 clone 函数以及相关代码
2. 返回一份 value 副本

## Test

### Before

被 clone 函数过滤, File 对象只有 uid 属性.

![clone1](https://user-images.githubusercontent.com/53422750/65812300-e2d08980-e1f7-11e9-9d28-cf23552dbba2.jpg)

### After

![image](https://user-images.githubusercontent.com/53422750/65812322-4064d600-e1f8-11e9-87e7-80032353fb35.png)

## Notice

`{...obj}` 会被 rollup 构建转换为如下代码:

```js
import _objectSpread from '@babel/runtime/helpers/objectSpread';

function getFormValue() {
  return _objectSpread({}, getValue(this.value, this._content));
}
```

`_objectSpread` 的实际代码为:

```js
function _defineProperty(obj, key, value) {
  if (key in obj) {
    Object.defineProperty(obj, key, {
      value: value,
      enumerable: true,
      configurable: true,
      writable: true
    });
  } else {
    obj[key] = value;
  }

  return obj;
}

module.exports = _defineProperty;

function _objectSpread(target) {
  for (var i = 1; i < arguments.length; i++) {
    var source = arguments[i] != null ? arguments[i] : {};
    var ownKeys = Object.keys(source);

    if (typeof Object.getOwnPropertySymbols === 'function') {
      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
      }));
    }

    ownKeys.forEach(function (key) {
      defineProperty(target, key, source[key]);
    });
  }

  return target;
}

module.exports = _objectSpread;
```