### PR TITLE
refactor: 不依赖特定的 element 包

### DIFF
--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -1,4 +1,3 @@
-import Form from 'element-ui/lib/form'
 import _set from 'lodash.set'
 import RenderFormGroup from './render-form-group'
 import RenderFormItem from './render-form-item'
@@ -13,7 +12,7 @@ export default {
     return h(
       'el-form',
       {
-        props: Object.assign({}, this._props, {
+        props: Object.assign({}, this.$attrs, {
           model: this.value // 用于校验
         }),
         ref: 'elForm'
@@ -57,7 +56,7 @@ export default {
   mounted() {
     this.$nextTick(() => {
       // proxy
-      Object.keys(Form.methods).forEach(item => {
+      Object.keys(this.$refs.elForm.$options.methods).forEach(item => {
         this[item] = this.$refs.elForm[item]
       })
 
@@ -76,7 +75,7 @@ export default {
       }
     })
   },
-  props: Object.assign({}, Form.props, {
+  props: {
     content: {
       type: Array,
       required: true
@@ -86,7 +85,7 @@ export default {
       type: Boolean,
       default: false
     }
-  }),
+  },
   data() {
     return {
       value: {}, // 表单数据对象


### PR DESCRIPTION
## Why

原本的代码中依赖了 element-ui 中的某些包，导致，需要使用私有化 element-ui 时，缺少依赖

## How
- Form.props 利用 $attrs 来代替
- Form.methods 使用 vm.$options.methods 来代替

## Test
组件改后没有什么变化，看 preview page 检验一下

搭配私有的 element-ui 使用不再报错了
![image](https://user-images.githubusercontent.com/27187946/68763592-c9728800-0653-11ea-928d-13a3af061bd9.png)

