### PR TITLE
fix: disabled not working

### DIFF
--- a/docs/disabled.md
+++ b/docs/disabled.md
@@ -1,4 +1,4 @@
-el-form-renderer 的属性 disabled 会禁用所有表单项
+el-form-renderer 的 disabled 属性会禁用所有表单项
 
 而 content 中每个表单元素的 el 对象内的 disabled 可以禁用对应的表单项
 

--- a/docs/disabled.md
+++ b/docs/disabled.md
@@ -1,0 +1,115 @@
+el-form-renderer 的属性 disabled 会禁用所有表单项
+
+而 content 中每个表单元素的 el 对象内的 disabled 可以禁用对应的表单项
+
+```vue
+<template>
+  <div>
+    <el-form-renderer label-width="100px" :content="content" ref="ruleForm" :disabled="disabledAll"></el-form-renderer>
+    <el-checkbox v-model="disabledAll">禁用全部</el-checkbox>
+    <el-checkbox v-model="disabledArea">禁用 area</el-checkbox>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      disabledAll: false,
+      disabledArea: false,
+      content: [
+        {
+          type: 'input',
+          id: 'name',
+          label: 'name',
+          attrs: { 'data-name': 'form1' },
+          el: {
+            size: 'mini',
+            placeholder: 'test placeholder'
+          },
+          rules: [
+            { required: true, message: 'miss name', trigger: 'blur' },
+            { min: 3, max: 5, message: 'length between 3 to 5', trigger: 'blur' }
+          ]
+        }, {
+          type: 'select',
+          id: 'region',
+          label: 'area',
+          el: {
+            disabled: false
+          },
+          options: [{
+            label: 'area1',
+            value: 'shanghai'
+          }, {
+            label: 'area2',
+            value: 'beijing'
+          }],
+          rules: [
+            { required: true, message: 'miss area', trigger: 'change' }
+          ]
+        }, {
+          type: 'date-picker',
+          id: 'date',
+          label: 'date',
+          el: {
+            type: 'datetime',
+            placeholder: 'select date'
+          },
+          rules: [
+            { type: 'date', required: true, message: 'miss date', trigger: 'change' }
+          ]
+        }, {
+          type: 'switch',
+          id: 'delivery',
+          label: 'delivery'
+        }, {
+          type: 'checkbox-group',
+          id: 'type',
+          label: 'type',
+          default: [],
+          options: [{
+            label: 'typeA'
+          }, {
+            label: 'typeB'
+          }, {
+            label: 'typeC'
+          }],
+          rules: [
+            { type: 'array', required: true, message: 'miss type', trigger: 'change' }
+          ]
+        }, {
+          type: 'radio-group',
+          id: 'resource',
+          label: 'resource',
+          options: [{
+            label: 'resourceA'
+          }, {
+            label: 'resourceB'
+          }],
+          rules: [
+            { required: true, message: 'miss resource', trigger: 'change' }
+          ]
+        }, {
+          type: 'input',
+          id: 'desc',
+          label: 'desc',
+          el: {
+            type: 'textarea'
+          },
+          rules: [
+            { required: true, message: 'miss desc', trigger: 'blur' }
+          ]
+        }
+      ]
+    }
+  },
+
+  watch: {
+    disabledArea(val) {
+      this.$set(this.content[1].el, 'disabled', val)
+    }
+  }
+}
+</script>
+```

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -80,11 +80,6 @@ export default {
       type: Array,
       required: true
     }
-    // 禁用所有表单
-    // disabled: {
-    //   type: Boolean,
-    //   default: false
-    // }
   },
   data() {
     return {

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -25,7 +25,7 @@ export default {
               data: item,
               value: this.value,
               itemValue: this.value[item.id],
-              disabled: this.disabled,
+              disabled: this.$attrs.disabled || false,
               options: this.options[item.id],
               // _parent 指向el-form, 在render-form-group里有用到
               _parent: this
@@ -79,12 +79,12 @@ export default {
     content: {
       type: Array,
       required: true
-    },
-    // 禁用所有表单
-    disabled: {
-      type: Boolean,
-      default: false
     }
+    // 禁用所有表单
+    // disabled: {
+    //   type: Boolean,
+    //   default: false
+    // }
   },
   data() {
     return {

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -25,7 +25,7 @@ export default {
               data: item,
               value: this.value,
               itemValue: this.value[item.id],
-              disabled: this.$attrs.disabled || false,
+              disabled: !!this.$attrs.disabled,
               options: this.options[item.id],
               // _parent 指向el-form, 在render-form-group里有用到
               _parent: this


### PR DESCRIPTION
## Why

- 由于使用了 $attrs 代替原来的 Form.props，同时组件自己声明了 disabled 的属性，所以导致丢失了 disabled 属性。

## How

Because el-form-renderer set a props `disabled`, these props can't inherit from el-form.

## Test
### Before
see why

### After
![image](https://user-images.githubusercontent.com/27187946/69625622-f1b1ac00-1081-11ea-862c-224bb90d7d69.png)


