### PR TITLE
docs: 修复 input-format 用例

### DIFF
--- a/docs/value-format.md
+++ b/docs/value-format.md
@@ -25,7 +25,9 @@
             id: 'date',
             label: 'date',
             inputFormat: (row) => {
-              return [row.startDate, row.endDate]
+              if (row.startDate && row.endDate) {
+                return [row.startDate, row.endDate]
+              }
             },
             outputFormat: (val) => {
               if (!val) {


### PR DESCRIPTION
在配合updateForm使用时被狠狠的摆了一道

close #137

## Why

文档稍微不够明细, 被🕳了一小下. :)  

## How

简要说明是 `updateForm` 不包含符合某个 `inputFormat` 的格式时, 会出现错误(只在结合 `el-date-picker`与其他表单项联合测试过)

## Docs

- value-format.md
