### PR TITLE
feat: 添加 content watch

### DIFF
--- a/docs/dynamic-add.md
+++ b/docs/dynamic-add.md
@@ -1,0 +1,37 @@
+```vue
+<template>
+  <div class="dynamic-page">
+   <el-button @click="handleAdd" icon="el-icon-plus" type="text">动态添加一行</el-button>
+   <el-form-renderer label-width="100px" :content="content" ref="ruleForm">
+    <el-form-item>
+    </el-form-item>
+  </el-form-renderer>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      content: [
+        {
+          type: 'input',
+          id: 'name',
+          label: 'name'
+        }
+      ]
+    }
+  },
+  methods: {
+    handleAdd() {
+      const key = `name${this.content.length}`;
+      this.content.push({
+        type: 'input',
+        id: key,
+        label: key
+      })
+    }
+  }
+}
+</script>
+```

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -49,9 +49,7 @@ export default {
     RenderFormGroup
   },
   beforeMount() {
-    this._content = transformContent(this.content)
-    this.initItemOption()
-    this._content.forEach(this.initItemValue)
+    this.init()
   },
   mounted() {
     this.$nextTick(() => {
@@ -90,6 +88,9 @@ export default {
     }
   },
   watch: {
+    content(val) {
+      val.length && this.init()
+    },
     _content: {
       handler(newVal) {
         if (!newVal.length) {
@@ -101,6 +102,14 @@ export default {
     }
   },
   methods: {
+    /**
+     * 初始化 content
+     */
+    init() {
+      this._content = transformContent(this.content)
+      this.initItemOption()
+      this._content.forEach(this.initItemValue)
+    },
     /**
      * 初始化每个表单原子的默认值
      * @param  {Object} item 表单原子描述


### PR DESCRIPTION
## Why
由于我的需求当中有动态添加表单的功能，因此我对组件的 `props` -> `content` 动态 `push` 了一行新的表单元素，发现没有反应，但数据确确实实已经修改了，翻阅源码后发现，`props` 中的 `content` 属性并没有被检测。

## How
- 效果
![效果](https://s2.ax1x.com/2019/12/07/Qt3oKH.gif)

