### PR TITLE
fix: disabled 优先级问题

### DIFF
--- a/docs/disabled.md
+++ b/docs/disabled.md
@@ -2,6 +2,9 @@ el-form-renderer 的 disabled 属性会禁用所有表单项
 
 而 content 中每个表单元素的 el 对象内的 disabled 可以禁用对应的表单项
 
+注意：
+ - 表单元素的 el 对象内的 disabled 的优先级比 el-form-renderer 的 disabled 属性高
+
 ```vue
 <template>
   <div>

--- a/src/el-form-renderer.js
+++ b/src/el-form-renderer.js
@@ -13,7 +13,8 @@ export default {
       'el-form',
       {
         props: Object.assign({}, this.$attrs, {
-          model: this.value // 用于校验
+          model: this.value, // 用于校验,
+          disabled: false // 不使用全局 disabled，由各表单项处理
         }),
         ref: 'elForm'
       },

--- a/src/render-form-item.js
+++ b/src/render-form-item.js
@@ -123,8 +123,10 @@ export default {
       const elType = data.type
       if (elType === 'checkbox-button') data.type = 'checkbox-group'
       else if (elType === 'radio-button') data.type = 'radio-group'
-      const props = {...obj, value, ...this.propsInner}
-      this.disabled && (props.disabled = this.disabled) // 只能全局禁用, false时不处理
+      const inheritProps = {
+        disabled: this.disabled
+      }
+      const props = {...inheritProps, ...obj, value, ...this.propsInner}
       const {updateForm} = this.$parent.$parent
       const {on = {}} = data
       return h(


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
如果在`el-form-render`设置了`disabled`，则使表单项内部的`disabled`无效（这是 element-ui 原本的设计），但是如果出现想禁用大部分，只开启其中一个的情况，会很繁琐。

## How
1. 取消`el-form`的`disabled`属性
2. 使表单项的`disabled`属性比`el-form`的`disabled`属性优先级高

## Docs
- docs/disabled.md
