### PR TITLE
fix: radio 传 value 时用作 label 属性

### DIFF
--- a/cypress/integration/v-model.spec.js
+++ b/cypress/integration/v-model.spec.js
@@ -55,7 +55,7 @@ describe('测试 v-model 示例', function() {
         endDate: '2019-01-03',
         type: ['typeA'],
         region: ['shanghai'],
-        resource: 'resourceA',
+        resource: 'A',
         desc: 'desc',
       }),
     )

--- a/docs/radio-group.md
+++ b/docs/radio-group.md
@@ -15,9 +15,13 @@ export default {
           label: 'city',
           default: 'new york',
           options: [
-            // warnning：element radio-group use label only
+            /**
+             * el-radio 用 label 来做 v-model 的值
+             * 这里会渲染成 <el-radio label="new york">new york</el-radio>
+             */
             { label: 'new york' },
-            { label: 'guangzhou' },
+            // 这里会渲染成 <el-radio label="a">guangzhou</el-radio>
+            { label: 'guangzhou', value: 'a' },
             { label: 'tokyo' },
           ]
         }

--- a/docs/v-model.md
+++ b/docs/v-model.md
@@ -104,9 +104,11 @@ export default {
           id: 'resource',
           label: 'resource',
           options: [{
-            label: 'resourceA'
+            label: 'resourceA',
+            value: 'A',
           }, {
-            label: 'resourceB'
+            label: 'resourceB',
+            value: 'B'
           }],
           rules: [
             { required: true, message: 'miss resource', trigger: 'change' }

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -37,13 +37,20 @@
           :key="opt.value"
           v-bind="opt"
         />
-        <!-- TODO: 支持 el-radio-button 变体 -->
-        <component
-          :is="`el-${data.type.slice(0, -6)}`"
-          v-else
+        <!-- TODO: 支持 el-checkbox-button 变体 -->
+        <el-checkbox
+          v-else-if="data.type === 'checkbox-group'"
           :key="opt.label"
           v-bind="opt"
-          >{{ opt.label }}</component
+        />
+        <!-- WARNING: radio 用 label 属性来表示 value 的含义 -->
+        <!-- FYI: radio 的 value 属性可以在没有 radio-group 时用来关联到同一个 v-model -->
+        <el-radio
+          v-else-if="data.type === 'radio-group'"
+          :key="opt.label"
+          v-bind="opt"
+          :label="'value' in opt ? opt.value : opt.label"
+          >{{ opt.label }}</el-radio
         >
       </template>
     </custom-component>


### PR DESCRIPTION
## Why
之前重构时，忽视了[这段代码](https://github.com/FEMessage/el-form-renderer/pull/161/commits/78902ef0a0763554be9ec586610d47ac99146ab2#diff-cbb007f154e6de9ad1badca8f1137687L20)的一个 hack 操作：对于 el-radio，有传 value 时优先用作 label 属性。

这是因为，el-radio 用 label 属性作为选中时 v-model 的值；而仅在没用 el-radio-group 时用 value 属性来关联到同一个 v-model。
[element 文档链接](https://element.eleme.cn/#/zh-CN/component/radio#dai-you-bian-kuang)

el-form-renderer 的既往实现是：
- 用传入的 label 作为展示值
- 用传入的 value（如果有）作为 label 属性

## How
恢复过往行为，补充注释

## Test
补充对 radio 传入 value 时的用例
![image](https://user-images.githubusercontent.com/19591950/74916276-7f423500-5400-11ea-92ed-7e32073f39f1.png)


## Docs
radio-group 文档中补充了说明
