### PR TITLE
fix: 修复 disabled 写在 el 中的用法

### DIFF
--- a/cypress/integration/disabled.spec.js
+++ b/cypress/integration/disabled.spec.js
@@ -7,8 +7,9 @@ describe('测试 disabled 示例', function() {
   })
   it('禁用全部', function() {
     cy.contains('disabled')
+    cy.$getFormItemInput('desc', 'textarea').should('be.disabled') // 测试 el.disabled
     cy.$getFormItemInput('name').should('be.enabled')
-    cy.contains('禁用全部').click()
+    cy.contains('禁用全部').click() // 测试全局 disabled
     cy.$getFormItemInput('name').should('be.disabled')
     cy.contains('禁用全部').click()
     cy.$getFormItemInput('name').should('be.enabled')

--- a/docs/disabled.md
+++ b/docs/disabled.md
@@ -1,6 +1,7 @@
-el-form-renderer 的 disabled 属性会禁用所有表单项
-
-而 content 中每个表单元素的 disabled 可以禁用对应的表单项
+disabled 可以设置在三个地方
+1. 作为 el-form-renderer 的 prop 传入，禁用整个表单项，优先级最高
+2. 作为 el 的属性传入，作用于单个表单项组件
+3. 与 el 平级传入，效果和 2 相同（因历史原因存在
 
 ```vue
 <template>
@@ -94,6 +95,7 @@ export default {
           id: 'desc',
           label: 'desc',
           el: {
+            disabled: true,
             type: 'textarea'
           },
           rules: [

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -10,7 +10,7 @@
       <div
         v-if="data.type === 'input'"
         :style="
-          data.el && data.el.type === 'textarea'
+          componentProps.type === 'textarea'
             ? {padding: '10px 0', lineHeight: 1.5}
             : ''
         "
@@ -26,9 +26,9 @@
     <custom-component
       v-else
       :component="data.component || `el-${data.type}`"
-      v-bind="{...data.el, ...propsInner}"
+      v-bind="componentProps"
       :value="itemValue"
-      :disabled="disabled || readonly"
+      :disabled="disabled || componentProps.disabled || readonly"
       v-on="listeners"
     >
       <template v-for="opt in options">
@@ -110,6 +110,8 @@ export default {
     }
   },
   computed: {
+    // 解构运算符会处理 undefined 的情况
+    componentProps: ({data: {el}, propsInner}) => ({...el, ...propsInner}),
     hasReadonlyContent: ({data: {type}}) =>
       _includes(['input', 'select'], type),
     hiddenStatus: ({data: {hidden = () => false}, data, value}) =>


### PR DESCRIPTION
## Why
fix #166 
其实之前 disabled 示例报错时就该警觉的。这个 breaking-change 是在 readonly 时不小心引入的，应该早点注意到

## How
disabled 兼容 el 中传入的情况

## Test
测试用例补充了三种 disabled 的情况
![image](https://user-images.githubusercontent.com/19591950/75020245-4d4ad480-54cd-11ea-8597-693669f0e348.png)

## Docs
在 disabled 文档中补充了三种 disabled 设置位置的说明
