### PR TITLE
perf: remote 仅在有效变更时发送请求

### DIFF
--- a/cypress/integration/content.spec.js
+++ b/cypress/integration/content.spec.js
@@ -8,6 +8,7 @@ describe('测试 content 示例', function() {
   it('基础用例', function() {
     cy.contains('禁用第一项').click()
     cy.$getFormItemInput('name').should('be.disabled')
+    cy.contains('requestRemoteCount: 1')
     cy.$getFormItemInput('region')
       .first()
       .click()
@@ -16,7 +17,9 @@ describe('测试 content 示例', function() {
     cy.contains('更新 region 的 options').click()
     cy.contains('shanghai').should('not.exist')
     cy.contains('广州').should('be.visible')
+    cy.contains('requestRemoteCount: 1') // 更改 content 配置不应重复请求 remote
     cy.contains('随机插入表单项').click()
     cy.contains('表单项1')
+    cy.contains('requestRemoteCount: 1') // 更改 content 配置不应重复请求 remote
   })
 })

--- a/docs/content.md
+++ b/docs/content.md
@@ -5,6 +5,9 @@
 ```vue
 <template>
   <el-form-renderer label-width="100px" :content="content" v-model="form" ref="form">
+    <template #id:region>
+      <div>requestRemoteCount: {{requestRemoteCount}}</div>
+    </template>
     <el-form-item>
       <el-button @click="resetForm">resetForm</el-button>
       <el-button @click="disableName">{{content[0].disabled ? '启' : '禁'}}用第一项</el-button>
@@ -28,6 +31,7 @@ export default {
         endDate: '2019-01-02'
       },
       id: 0,
+      requestRemoteCount: 0,
       content: [
         {
           type: 'input',
@@ -46,20 +50,27 @@ export default {
           type: 'select',
           id: 'region',
           label: 'region',
-          options: [
-            {
-              label: 'shanghai',
-              value: 'shanghai'
-            }, 
-            {
-              label: 'beijing',
-              value: 'beijing'
-            },
-            {
-              label: 'guangzhou',
-              value: 'guangzhou'
-            },
-          ],
+          remote: {
+            // url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-form-renderer?q=remote',
+            request: () => {
+              const data = [
+                {
+                  label: 'shanghai',
+                  value: 'shanghai'
+                }, 
+                {
+                  label: 'beijing',
+                  value: 'beijing'
+                },
+                {
+                  label: 'guangzhou',
+                  value: 'guangzhou'
+                },
+              ]
+              this.requestRemoteCount++
+              return new Promise(r => setTimeout(() => r(data), 2000))
+            }
+          },
           el: {filterable: true, multiple: true, multipleLimit: 2},
           rules: [
             { required: true, message: 'miss area', trigger: 'change' }

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -171,8 +171,11 @@ export default {
      * 2. 针对 select、checkbox-group & radio-group 组件，会直接将 resp 作为 options 处理；label & value 也是直接为这个场景而生的
      */
     'data.remote': {
-      handler(v) {
+      handler(v, oldV) {
         if (!v) return
+        if (oldV) {
+          if (v.url === oldV.url || v.request === oldV.request) return
+        }
         const isOptionsCase =
           ['select', 'checkbox-group', 'radio-group'].indexOf(this.data.type) >
           -1


### PR DESCRIPTION
## Why
fix #168 
参考：https://github.com/FEMessage/el-form-renderer/pull/139#discussion_r355105584

## How
仅在 url 或 request 有变更时发送请求

## Test
### content
现在 content 示例会记录 request 调用的次数。content.spec.js 用例会检查 request 是否仅被调用一次。
![image](https://user-images.githubusercontent.com/19591950/75127519-84ea9400-56fa-11ea-9630-7352038a91da.png)

### 其他测试
![image](https://user-images.githubusercontent.com/19591950/75127559-bbc0aa00-56fa-11ea-8364-27fe23fb65f7.png)
