### PR TITLE
fix: 表单项的值为对象类型时错误覆盖回整个表单的值中

### DIFF
--- a/src/el-form-renderer.md
+++ b/src/el-form-renderer.md
@@ -162,11 +162,13 @@ interface Content {
   label?: string //set el-form-item's label
   trim = true // trim value at change event
 
-  // 用于处理输入值，辅助updateForm进行对应值更新，参数为updateForm传入的对象
+  // 用于处理输入值，输入的值包括：1. default；2. v-model；3. updateForm。参数为整个表单的值对象或 updateForm 传入的对象
+  // 如果 inputFormat 返回 undefined，则不会更新此表单项
   // obj is param you passed to updateForm. You can use this function to hijack this process and customize the form value
   inputFormat?: (obj: any) => any
 
   // 用于处理输出值，参数为对应组件返回值
+  // 如果处理后的值是对象类型，会覆盖（Object.assign）到整个表单的值上
   // used to hijack the getFormValue's process and customize the return value
   outputFormat?: (val: any) => any
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -116,6 +116,19 @@ describe('transformOutputValue', () => {
     ]
     expect(transformOutputValue(oldV, content)).toEqual(newV)
   })
+  test('没 outputFormat 时，对象值不会被覆盖到外层', () => {
+    const v = {
+      a: {
+        b: 1,
+      },
+    }
+    const content = [
+      {
+        id: 'a',
+      },
+    ]
+    expect(transformOutputValue(v, content)).toEqual(v)
+  })
 })
 
 describe('transformInputValue', () => {
@@ -127,7 +140,7 @@ describe('transformInputValue', () => {
       },
     }
     const newV = {
-      a: 1,
+      a: 0,
       b: {
         c: 2,
       },
@@ -135,7 +148,7 @@ describe('transformInputValue', () => {
     const content = [
       {
         id: 'a',
-        inputFormat: v => v.aa,
+        inputFormat: v => v.aa - 1,
       },
       {
         id: 'b',


### PR DESCRIPTION
## How
该行为应该只在有 outputFormat 时才出现

### 参考
现在和重构前 outputFormat 行为一致了
![image](https://user-images.githubusercontent.com/19591950/75310995-51da0900-5890-11ea-9450-f018ef239398.png)

## Test
### 单测
单测中补充了该情景
![image](https://user-images.githubusercontent.com/19591950/75310116-fe66bb80-588d-11ea-81a9-3e8b3d269de9.png)

### 端测
![image](https://user-images.githubusercontent.com/19591950/75310070-d7a88500-588d-11ea-9e4e-12579f22c9ae.png)

### 项目测试
发私服到出错页面
![image](https://user-images.githubusercontent.com/19591950/75310365-c318bc80-588e-11ea-9bea-e085802be856.png)

## Docs
inputFormat & outputFormat 的行为补充到 api 文档中
