### PR TITLE
fix: 修复 resetFields 有时无法恢复初始值的问题

### DIFF
--- a/cypress/integration/basic.spec.js
+++ b/cypress/integration/basic.spec.js
@@ -20,6 +20,6 @@ describe('测试 basic 示例', function() {
     cy.contains('submit').click()
     cy.contains('submit!')
     cy.contains('reset').click()
-    cy.$getFormItemInput('name').should('be.empty')
+    cy.$getFormItemInput('name').should('have.value', '')
   })
 })

--- a/cypress/integration/next-tick.spec.js
+++ b/cypress/integration/next-tick.spec.js
@@ -1,0 +1,15 @@
+/// <reference types="Cypress" />
+
+describe('测试 next-tick 示例', function() {
+  beforeEach(() => {
+    cy.visit('/')
+    cy.$goto('next-tick')
+  })
+  it('在 dialog 中的情况', function() {
+    cy.contains('点击打开 Dialog（带数据）').click()
+    cy.$getFormItemInput('姓名').should('have.value', '小明')
+    cy.get('.el-dialog__headerbtn').click()
+    cy.contains(/^点击打开 Dialog$/).click()
+    cy.$getFormItemInput('姓名').should('have.value', '')
+  })
+})

--- a/cypress/integration/update-form.spec.js
+++ b/cypress/integration/update-form.spec.js
@@ -6,7 +6,7 @@ describe('测试 update-form 示例', function() {
     cy.$goto('update-form')
   })
   it('基础用例', function() {
-    cy.$getFormItemInput('name').should('be.empty')
+    cy.$getFormItemInput('name').should('have.value', '')
     cy.contains('button', 'set name as alvin').click()
     cy.$getFormItemInput('name').should('have.value', 'alvin')
   })

--- a/docs/next-tick.md
+++ b/docs/next-tick.md
@@ -3,9 +3,10 @@ $nextTick
 ```vue
 <template>
   <div class="nextTick">
+    <el-button type="text" @click="openDialogWithData">点击打开 Dialog（带数据）</el-button>
     <el-button type="text" @click="dialogVisible = true">点击打开 Dialog</el-button>
 
-    <el-dialog :visible.sync="dialogVisible" title="Next Tick" @open="handleOpen">
+    <el-dialog :visible.sync="dialogVisible" title="Next Tick" @open="handleOpen" ref="dialog" @close="onClose">
       <el-form-renderer :content="content" inline ref="formRender" />
     </el-dialog>
   </div>
@@ -36,6 +37,17 @@ $nextTick
         this.$nextTick(() => {
           console.log(this.$refs.formRender)  // 始终能获取到该实例
         })
+      },
+      openDialogWithData() {
+        this.dialogVisible = true
+        this.$refs.dialog.$once('opened', () => {
+          this.$refs.formRender.updateForm({
+            name: '小明'
+          })
+        })
+      },
+      onClose() {
+        this.$refs.formRender.resetFields()
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/FEMessage/el-form-renderer",
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "lodash.frompairs": "^4.0.1",
     "lodash.get": "^4.4.2",
     "lodash.has": "^4.5.2",

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -21,6 +21,7 @@
 <script>
 import _set from 'lodash.set'
 import _isequal from 'lodash.isequal'
+import _clonedeep from 'lodash.clonedeep'
 import RenderFormGroup from './components/render-form-group.vue'
 import RenderFormItem from './components/render-form-item.vue'
 import transformContent from './util/transform-content'
@@ -112,6 +113,11 @@ export default {
     },
   },
   mounted() {
+    /**
+     * 与 element 相同，在 mounted 阶段存储 initValue
+     * @see https://github.com/ElemeFE/element/blob/6ec5f8e900ff698cf30e9479d692784af836a108/packages/form/src/form-item.vue#L304
+     */
+    this.initValue = _clonedeep(this.value)
     this.$nextTick(() => {
       // proxy
       Object.keys(this.$refs.elForm.$options.methods).forEach(item => {
@@ -124,7 +130,6 @@ export default {
        * @hack
        */
       this.clearValidate()
-      this.initValue = this.value
     })
   },
   methods: {
@@ -146,7 +151,7 @@ export default {
        *   3. 点击 reset 按钮，此时 log 两条数据： '1' '1', '' ''
        *   4. 因为 _isequal(v, oldV)，所以没有触发 v-model 更新
        */
-      this.value = this.initValue
+      this.value = _clonedeep(this.initValue)
       this.$nextTick(this.clearValidate)
     },
     setValueFromModel() {


### PR DESCRIPTION
## Why
原本的 initValue 会被 updateForm 污染，因为 updateForm 里有个 mergeValue 的步骤

## How
现在 initValue 在生成和使用的时候都会 clonedeep

## Test
### 新增 next-tick 测试
模拟 el-data-table 场景
![image](https://user-images.githubusercontent.com/19591950/75326561-d3905d80-58b5-11ea-862a-b67133fb91e7.png)

### 全场景端测
![image](https://user-images.githubusercontent.com/19591950/75326536-c70c0500-58b5-11ea-821b-b1206336aca6.png)