### PR TITLE
fix: 修复 v-model & content 示例中修改 date range 报错的问题

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -84,7 +84,7 @@ export default {
             valueFormat: 'yyyy-MM-dd'
           },
           rules: [
-            { type: 'date', required: true, message: 'miss date', trigger: 'change' }
+            { required: true, message: 'miss date', trigger: 'change' }
           ],
           inputFormat: (row) => {
             if (row.startDate && row.endDate) {

--- a/docs/v-model.md
+++ b/docs/v-model.md
@@ -64,7 +64,7 @@ export default {
             valueFormat: 'yyyy-MM-dd'
           },
           rules: [
-            { type: 'date', required: true, message: 'miss date', trigger: 'change' }
+            { required: true, message: 'miss date', trigger: 'change' }
           ],
           inputFormat: (row) => {
             if (row.startDate && row.endDate) {


### PR DESCRIPTION
## Why
date-picker 是 type: daterange 的话 rules 里不能填 type: date；之前 copy 后没留意这个问题