### PR TITLE
fix: 正确的 `getFormValue` 获取表单值

### DIFF
--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -180,7 +180,7 @@ export default {
      * @public
      */
     getFormValue() {
-      return transformOutputValue(this.value, this.content)
+      return transformOutputValue(this.value, this.innerContent)
     },
     /**
      * update form values


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why

`getFormValue` 应该是根据处理过后的表单项配置来返回 `value`


## Test

### e2e

![image](https://user-images.githubusercontent.com/53422750/76492988-82af6600-646c-11ea-8d91-1e840ad653fc.png)

### 自身函数测试

```console
 PASS  test/custom-component-rules.test.js
  自定义组件规则
    ✓ 调用函数返回规则 (8ms)
    ✓ 获取静态规则 (1ms)

 PASS  test/transform-content.test.js
  ✓ transform content (12ms)

 PASS  test/hidden.test.js
  mixin-hidden.js
    enableWhen 与 hidden
      ✓ 没有使用 enableWhen 与 hidden (13ms)
      ✓ 使用 enableWhen，不被 hidden 干扰 (6ms)
      ✓ 同时使用 hidden 与 enableWhen，取并集 (2ms)
    使用 hidden
      ✓ 使用 hidden，返回 true，不显示 (1ms)
      ✓ 使用 hidden，返回 false，显示 (1ms)
    hidden 可以使用 form 与当前 item 值
      ✓ hidden 可以获取 form 值 (1ms)
      ✓ hidden 可以获取 item 信息 (1ms)

 PASS  test/utils.test.js
  collect
    ✓ initial item options (2ms)
  mergeValue
    ✓ 合并带 group 的情况 (1ms)
  transformOutputValue
    ✓ 合并带 group 的情况 (1ms)
    ✓ 没 outputFormat 时，对象值不会被覆盖到外层
  transformInputValue
    ✓ 合并带 group 的情况

 PASS  test/set-options.test.js
  ✓ set options (2ms)

Test Suites: 5 passed, 5 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        4.412s
Ran all test suites.
```

### el-data-table 中测试

![fix-get-form-value](https://user-images.githubusercontent.com/53422750/76492692-c81f6380-646b-11ea-8a06-da4ad06160ca.gif)
