### PR TITLE
fix: 解决 select 为 multiple 时 readonly 无法显示的问题

### DIFF
--- a/docs/readonly.md
+++ b/docs/readonly.md
@@ -45,6 +45,24 @@ export default {
             { required: true, message: 'miss area', trigger: 'change' }
           ]
         }, {
+          default: ['shanghai','beijing'],
+          type: 'select',
+          id: 'multi-region',
+          label: 'multi area',
+          options: [{
+            label: '上海',
+            value: 'shanghai'
+          }, {
+            label: '北京',
+            value: 'beijing'
+          }],
+          el: {
+            multiple: true
+          },
+          rules: [
+            { required: true, message: 'miss area', trigger: 'change' }
+          ]
+        }, {
           default: '[native Date Wed Jan 01 2020 00:00:00 GMT+0800 (中国标准时间)]',
           type: 'date-picker',
           id: 'date',

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -18,9 +18,19 @@
         {{ itemValue }}
       </div>
       <div v-else-if="data.type === 'select'">
-        {{
-          (data.options.find(op => op.value === itemValue) || {label: ''}).label
-        }}
+        <template v-if="get(data, 'el.multiple')">
+          {{
+            (itemValue || [])
+              .map(val => data.options.find(op => op.value === val).label)
+              .join()
+          }}
+        </template>
+        <template v-else>
+          {{
+            (data.options.find(op => op.value === itemValue) || {label: ''})
+              .label
+          }}
+        </template>
       </div>
     </template>
     <custom-component
@@ -107,6 +117,7 @@ export default {
         this.data.rules.some(rule => {
           return rule.required && rule.trigger === 'blur'
         }),
+      get: _get,
     }
   },
   computed: {

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -226,7 +226,6 @@ export default {
     },
   },
   methods: {
-    _get,
     triggerValidate(id) {
       if (!this.data.rules || !this.data.rules.length) return
 

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -18,17 +18,13 @@
         {{ itemValue }}
       </div>
       <div v-else-if="data.type === 'select'">
-        <template v-if="_get(data, 'el.multiple')">
+        <template>
           {{
-            (itemValue || [])
-              .map(val => data.options.find(op => op.value === val).label)
+            (_get(data, 'el.multiple') ? itemValue : [itemValue] || [])
+              .map(
+                val => (data.options.find(op => op.value === val) || {}).label,
+              )
               .join()
-          }}
-        </template>
-        <template v-else>
-          {{
-            (data.options.find(op => op.value === itemValue) || {label: ''})
-              .label
           }}
         </template>
       </div>

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -19,13 +19,7 @@
       </div>
       <div v-else-if="data.type === 'select'">
         <template>
-          {{
-            (_get(data, 'el.multiple') ? itemValue : [itemValue] || [])
-              .map(
-                val => (data.options.find(op => op.value === val) || {}).label,
-              )
-              .join()
-          }}
+          {{ multipleValue }}
         </template>
       </div>
     </template>
@@ -167,6 +161,16 @@ export default {
           this.triggerValidate(id)
         },
       }
+    },
+
+    multipleValue({data, itemValue}) {
+      const multipleSelectValue =
+        _get(data, 'el.multiple') && Array.isArray(itemValue)
+          ? itemValue
+          : [itemValue]
+      return multipleSelectValue
+        .map(val => (data.options.find(op => op.value === val) || {}).label)
+        .join()
     },
   },
   watch: {

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -18,7 +18,7 @@
         {{ itemValue }}
       </div>
       <div v-else-if="data.type === 'select'">
-        <template v-if="get(data, 'el.multiple')">
+        <template v-if="_get(data, 'el.multiple')">
           {{
             (itemValue || [])
               .map(val => data.options.find(op => op.value === val).label)
@@ -117,7 +117,6 @@ export default {
         this.data.rules.some(rule => {
           return rule.required && rule.trigger === 'blur'
         }),
-      get: _get,
     }
   },
   computed: {
@@ -227,6 +226,7 @@ export default {
     },
   },
   methods: {
+    _get,
     triggerValidate(id) {
       if (!this.data.rules || !this.data.rules.length) return
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
select 为 multiple 时 readonly 则无法匹配值

## How
Describe your steps:
1. 在 select 为 multiple 时则根据值数组逐一匹配，使用`,`分割多个值

## Test
### e2e
![image](https://user-images.githubusercontent.com/27952659/76496500-294b3500-6474-11ea-9cce-6d8b49480362.png)
### jest
```shell
 PASS  test/transform-content.test.js
  ✓ transform content (12ms)

 PASS  test/utils.test.js
  collect
    ✓ initial item options (13ms)
  mergeValue
    ✓ 合并带 group 的情况 (2ms)
  transformOutputValue
    ✓ 合并带 group 的情况 (1ms)
    ✓ 没 outputFormat 时，对象值不会被覆盖到外层
  transformInputValue
    ✓ 合并带 group 的情况 (4ms)

 PASS  test/custom-component-rules.test.js
  自定义组件规则
    ✓ 调用函数返回规则 (3ms)
    ✓ 获取静态规则

 PASS  test/hidden.test.js
  mixin-hidden.js
    enableWhen 与 hidden
      ✓ 没有使用 enableWhen 与 hidden (9ms)
      ✓ 使用 enableWhen，不被 hidden 干扰 (3ms)
      ✓ 同时使用 hidden 与 enableWhen，取并集 (1ms)
    使用 hidden
      ✓ 使用 hidden，返回 true，不显示
      ✓ 使用 hidden，返回 false，显示 (1ms)
    hidden 可以使用 form 与当前 item 值
      ✓ hidden 可以获取 form 值 (1ms)
      ✓ hidden 可以获取 item 信息 (1ms)

 PASS  test/set-options.test.js
  ✓ set options (2ms)

Test Suites: 5 passed, 5 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        5.878s, estimated 12s
Ran all test suites.
✨  Done in 10.14s.
```
## Preview
![image](https://user-images.githubusercontent.com/27952659/76496912-f5244400-6474-11ea-8132-34d43be7722c.png)

## Docs
readonly 示例新增一项 select 为 multiple 的例子
