### PR TITLE
fix: 兼容 type 的 camelCase 写法

### DIFF
--- a/cypress/integration/deprecated.spec.js
+++ b/cypress/integration/deprecated.spec.js
@@ -1,0 +1,15 @@
+/// <reference types="Cypress" />
+
+describe('测试 deprecated 示例', function() {
+  beforeEach(() => {
+    cy.visit('/')
+    cy.$goto('deprecated')
+  })
+  it('基础用例', function() {
+    cy.contains('getFormValue').click()
+    cy.contains('{}')
+    cy.contains('resourceA').click()
+    cy.contains('getFormValue').click()
+    cy.contains('{"resource":"resourceA"}')
+  })
+})

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,0 +1,40 @@
+这里是些过时的写法，但仍要保留兼容性
+
+```vue
+<template>
+  <el-form-renderer ref="form" label-width="100px" :content="content">
+    <el-button @click="getFormValue">getFormValue</el-button>
+  </el-form-renderer>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      content: [
+        {
+          type: 'radioGroup', // 推荐写作 radio-group
+          $id: 'resource', // 推荐不加 $
+          label: 'resource',
+          options: [{
+            label: 'resourceA'
+          }, {
+            label: 'resourceB'
+          }],
+          rules: [
+            { required: true, message: 'miss resource', trigger: 'change' }
+          ]
+        }
+      ]
+    }
+  },
+  methods: {
+    getFormValue() {
+      const v = this.$refs.form.getFormValue()
+      // console.log(v)
+      this.$message(JSON.stringify(v))
+    }
+  }
+}
+</script>
+```

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash.includes": "^4.3.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
+    "lodash.kebabcase": "^4.1.1",
     "lodash.set": "^4.3.2",
     "lodash.topairs": "^4.3.0"
   },

--- a/src/util/transform-content.js
+++ b/src/util/transform-content.js
@@ -1,3 +1,4 @@
+import _kebabcase from 'lodash.kebabcase'
 /**
  * content 的每一项会浅拷贝一层
  * 只可以在 item 层新增修改属性，如 item.a = b
@@ -10,6 +11,8 @@ export default function transformContent(content) {
     } else {
       removeDollarInKey(item)
       extractRulesFromComponent(item)
+      // 有些旧写法是 checkboxGroup & radioGroup
+      item.type = _kebabcase(item.type)
     }
 
     return item

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,6 +6976,11 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npm.taobao.org/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
+
 lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"


### PR DESCRIPTION
## Why
恢复兼容性

## How
在 transform content 阶段改写所有 type

## Test
![image](https://user-images.githubusercontent.com/19591950/76597450-7514e180-653b-11ea-80c7-a2fab6b632eb.png)
![image](https://user-images.githubusercontent.com/19591950/76597452-76460e80-653b-11ea-8825-f0ef0e0ec4ee.png)


## Docs
加了个 deprecated 示例，专门展示旧写法
