### PR TITLE
feat: 改进 input 的 readonly 样式

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -55,6 +55,7 @@ el-data-table、el-data-tree 等组件内部集成该组件，用于更加灵活
 - 支持 `hidden` 进行表单项动态显示与隐藏
 - 支持渲染自定义组件
 - 支持自定义组件设置校验规则
+- 支持 v-model
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -66,6 +67,7 @@ el-data-table、el-data-tree 等组件内部集成该组件，用于更加灵活
 - [fem-vscode-helper](https://marketplace.visualstudio.com/items?itemName=FEMessage.fem-vscode-helper)
 - [实践案例](https://zhuanlan.zhihu.com/p/95725645)
 - [设置动态 options 指南](https://zhuanlan.zhihu.com/p/97827063)
+- [v-model 落地实践分析](https://zhuanlan.zhihu.com/p/108055158)
 
 [⬆ Back to Top](#table-of-contents)
 
@@ -86,13 +88,13 @@ yarn add @femessage/el-form-renderer
 
   export default {
     components: {
-      ElFormRenderer
+      ElFormRenderer,
     },
     data() {
       return {
-        content: []
+        content: [],
       }
-    }
+    },
   }
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In our daily development, there are lots page with form, and usually the form st
 - Support batch update form data with updateForm method
 - Support setOptions method, dynamically change select options
 - Content support `inputFormat` , `outputFormat` , `trim` to process component's input and output values
+- Support v-model
 
 [⬆Back to Top](#table-of-contents)
 
@@ -67,13 +68,13 @@ yarn add @femessage/el-form-renderer
   import ElFormRenderer from '@femessage/el-form-renderer'
   export default {
     components: {
-      ElFormRenderer
+      ElFormRenderer,
     },
     data() {
       return {
-        content: []
+        content: [],
       }
-    }
+    },
   }
 </script>
 ```

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -3,20 +3,18 @@
     v-show="_show"
     :prop="prop"
     :label="data.label"
-    :rules="_show && Array.isArray(data.rules) ? data.rules : []"
+    :rules="!readonly && Array.isArray(data.rules) ? data.rules : []"
     v-bind="data.attrs"
+    class="render-form-item"
   >
     <template v-if="readonly && hasReadonlyContent">
-      <div
+      <el-input
         v-if="data.type === 'input'"
-        :style="
-          componentProps.type === 'textarea'
-            ? {padding: '10px 0', lineHeight: 1.5}
-            : ''
-        "
-      >
-        {{ itemValue }}
-      </div>
+        v-bind="componentProps"
+        :value="itemValue"
+        readonly
+        v-on="listeners"
+      />
       <div v-else-if="data.type === 'select'">
         <template>
           {{ multipleValue }}
@@ -255,3 +253,14 @@ export default {
   },
 }
 </script>
+<style lang="less">
+.render-form-item {
+  textarea[readonly] {
+    border: 1px solid #dcdee6; // 只读状态不要有 focus 状态
+  }
+
+  input[readonly] {
+    border: 1px solid #dcdee6;
+  }
+}
+</style>


### PR DESCRIPTION
## Why
close #184; close #183 

input & textarea 的 readonly 模式只考虑了 label 在 左侧的定位；当 label 在其他位置时就会很丑陋了。

## How
用回 el-input，并用 css 固定样式，不会有 focus 时的蓝色边框

## Test
### Before
![image](https://user-images.githubusercontent.com/19591950/82988201-5ea30000-a02b-11ea-9982-446bfa1fcc39.png)

### After
![image](https://user-images.githubusercontent.com/19591950/82988246-6d89b280-a02b-11ea-8eac-cb89e3b092c7.png)

## Docs
顺便更新了 README，补充提及 v-model 功能

