### PR TITLE
fix: change content remote no trigger

### DIFF
--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -1,11 +1,11 @@
 <template>
   <el-form ref="elForm" v-bind="$attrs" :model="value" class="el-form-renderer">
-    <template v-for="item in innerContent">
+    <template v-for="(item, index) in innerContent">
       <slot :name="`id:${item.id}`" />
       <slot :name="`$id:${item.id}`" />
       <component
         :is="item.type === GROUP ? 'render-form-group' : 'render-form-item'"
-        :key="item.id"
+        :key="`${item.id}_${index}`"
         :data="item"
         :value="value"
         :item-value="value[item.id]"


### PR DESCRIPTION
## Why
修复 `content` 修改后，`remote` 不重新请求问题. 

ps: 请注意需要请求的 `item` 切换的时候位置换了

![xxx](https://user-images.githubusercontent.com/20502762/86519474-9d6b7780-be6d-11ea-9139-4a0bfaa32ee5.gif)

## How
1.`vue` 渲染数组有就地复用原则，如果 `key` 相同，则不会重新渲染。
2. 当 `content` 修改后，如果 `remote` 对应的 `Item` 在后面被切换了位置的话.
3. `watch innerContent`  会被执行, `options` 会重新收集，导致异步获取的 `options` 丢失。
4. 最后由于复用原则，需要异步获取 `options`的 `form-item` 没有重新触发 `remote`

