### PR TITLE
fix: judge the parent name

### DIFF
--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -16,9 +16,7 @@
         v-on="listeners"
       />
       <div v-else-if="data.type === 'select'">
-        <template>
-          {{ multipleValue }}
-        </template>
+        <template>{{ multipleValue }}</template>
       </div>
     </template>
     <custom-component
@@ -212,7 +210,7 @@ export default {
           .then(resp => {
             if (isOptionsCase) {
               let formRenderer = this.$parent
-              while (formRenderer.$options._componentTag !== 'el-form-renderer')
+              while (!formRenderer.isElFormRenderer)
                 formRenderer = formRenderer.$parent
               formRenderer.setOptions(this.prop, resp)
             } else {

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -71,6 +71,10 @@ export default {
   },
   data() {
     return {
+      /**
+       * 用来给子组件递归 options 判断是否是父容器的标识
+       */
+      isElFormRenderer: true,
       GROUP,
       /**
        * inputFormat 让整个输入机制复杂了很多。value 有以下输入路径:


### PR DESCRIPTION
## Why
源码中此处判断，是写死的组件名称，但是用户注册可能不会使用这个名称.

![image](https://user-images.githubusercontent.com/20502762/86519499-eae7e480-be6d-11ea-8404-5d15c212070d.png)

所以添加了一个变量去判断最近的 `el-form-renderer`

in `render-form-item.vue`
```diff
- while (formRenderer.$options._componentTag !== 'el-form-renderer')
+ while (!formRenderer.isElFormRenderer)
```

in `el-form-renderer.vue`
```diff
data() {
   return {
+    isElFormRenderer: true,
      GROUP,
     ...
  }
}
```