### PR TITLE
fix: fix the options lost

### DIFF
--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -100,7 +100,7 @@ export default {
     innerContent: {
       handler(v) {
         // 如果 content 没有变动 remote 的部分，这里需要保留之前 remote 注入的 options
-        this.options = {...oldOptions, ...collect(v, 'options')}
+        this.options = {...this.options, ...collect(v, 'options')}
         this.setValueFromModel()
       },
       immediate: true,

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -99,7 +99,8 @@ export default {
     },
     innerContent: {
       handler(v) {
-        this.options = collect(v, 'options')
+        const oldOptions = {...this.options}
+        this.options = {...oldOptions, ...collect(v, 'options')}
         this.setValueFromModel()
       },
       immediate: true,

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -99,7 +99,7 @@ export default {
     },
     innerContent: {
       handler(v) {
-        const oldOptions = {...this.options}
+        // 如果 content 没有变动 remote 的部分，这里需要保留之前 remote 注入的 options
         this.options = {...oldOptions, ...collect(v, 'options')}
         this.setValueFromModel()
       },


### PR DESCRIPTION
## Why
the remote options will be lose when the content attrs change

## How
1. I have a `form-renderer` content that it contains a select with remote attrs
2. when the content change. the innerContent `watch` will trigger.
3. the components options will collect again but it only collect the static options. https://github.com/FEMessage/el-form-renderer/blob/dev/src/el-form-renderer.vue#L102
4. I think it should merge the old options can resolve this problem

## Test
I try it in my local project with npm link.

it run fine.

ps: it looks like also has a little problem. the form value reset when the content value change... I think it is the author design ?



![屏幕录制2020-07-05下午11 55 29](https://user-images.githubusercontent.com/20502762/86536928-04e10000-bf1e-11ea-9957-6011eaf54aa1.gif)


