### PR TITLE
fix: 变更 content 时保留旧的表单值

### DIFF
--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -165,7 +165,10 @@ export default {
         ? transformInputValue(this.form, this.innerContent)
         : collect(this.innerContent, 'default')
       correctValue(newValue, this.innerContent)
-      if (!_isequal(this.value, newValue)) this.value = newValue
+      if (!_isequal(this.value, newValue)) {
+        // 同时保留旧的表单值
+        this.value = {...this.value, ...newValue}
+      }
     },
     /**
      * 更新表单数据

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -166,8 +166,9 @@ export default {
         : collect(this.innerContent, 'default')
       correctValue(newValue, this.innerContent)
       if (!_isequal(this.value, newValue)) {
-        // 同时保留旧的表单值
-        this.value = {...this.value, ...newValue}
+        // 排除不在 `content` 的表单项
+        const oldValue = this.getFormValue()
+        this.value = {...oldValue, ...newValue}
       }
     },
     /**

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -43,6 +43,9 @@ export function transformOutputValue(value, content) {
   const newVal = {}
   Object.keys(value).forEach(id => {
     const item = content.find(item => item.id === id)
+    // 无此 item 时不做任何操作
+    // 此情况出现在动态减表单项，防止出现错误
+    if (!item) return
     if (item.type !== 'group') {
       if (item.outputFormat) {
         const v = item.outputFormat(value[id])


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why

#188 

> ps: it looks like also has a little problem. the form value reset when the content value change... I think it is the author design ?

`setValueFromModel` **可能**只是没有考虑到是否保留旧的表单值情况，或者**顾名思义**

## Test

### before

留意「来源渠道」

![](https://user-images.githubusercontent.com/20502762/86536928-04e10000-bf1e-11ea-9957-6011eaf54aa1.gif)

### after

![keep-value](https://user-images.githubusercontent.com/53422750/86731639-51355880-c062-11ea-975f-0e0baab48b4e.gif)
