### PR TITLE
fix: 获取父实例对象由遍历改为注入的形式

### DIFF
--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -83,6 +83,10 @@ export default {
       render: (h, ctx) => h(ctx.props.component, ctx.data, ctx.children),
     },
   },
+  /**
+   * elForm inject from https://github.com/ElemeFE/element/blob/dev/packages/form/src/form.vue#L19
+   */
+  inject: ['elFormRenderer', 'elForm'],
   props: {
     data: Object,
     prop: {
@@ -211,10 +215,7 @@ export default {
           .then(onResponse, onError)
           .then(resp => {
             if (isOptionsCase) {
-              let formRenderer = this.$parent
-              while (formRenderer.$options._componentTag !== 'el-form-renderer')
-                formRenderer = formRenderer.$parent
-              formRenderer.setOptions(this.prop, resp)
+              this.elFormRenderer.setOptions(this.prop, resp)
             } else {
               this.propsInner = {[prop]: resp}
             }
@@ -227,27 +228,9 @@ export default {
     triggerValidate(id) {
       if (!this.data.rules || !this.data.rules.length) return
 
-      /**
-       * 下面代码可参考 `emitter`
-       * 目的: 为了清除表单校验信息
-       * 因为有部分表单项的值变更时没有清除校验信息, 因此需要触发一次校验用于清除
-       * https://github.com/ElemeFE/element/blob/dev/src/mixins/emitter.js
-       */
-      let parent = this.$parent
-      let name = parent.$options.componentName
-
-      while (parent && name !== 'ElForm') {
-        parent = parent.$parent
-
-        if (parent) {
-          name = parent.$options.componentName
-        }
-      }
-
-      if (!parent || this.isBlurTrigger) return
-
+      if (this.isBlurTrigger) return
       this.$nextTick(() => {
-        parent.validateField(id)
+        this.elForm.validateField(id)
       })
     },
   },

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -215,7 +215,8 @@ export default {
           .then(onResponse, onError)
           .then(resp => {
             if (isOptionsCase) {
-              this.elFormRenderer.setOptions(this.prop, resp)
+              this.elFormRenderer &&
+                this.elFormRenderer.setOptions(this.prop, resp)
             } else {
               this.propsInner = {[prop]: resp}
             }
@@ -230,7 +231,7 @@ export default {
 
       if (this.isBlurTrigger) return
       this.$nextTick(() => {
-        this.elForm.validateField(id)
+        this.elForm && this.elForm.validateField(id)
       })
     },
   },

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -41,6 +41,11 @@ export default {
     RenderFormItem,
     RenderFormGroup,
   },
+  provide() {
+    return {
+      elFormRenderer: this,
+    }
+  },
   /**
    * value 已经被内部大量使用，所以换用 form
    */

--- a/test/hidden.test.js
+++ b/test/hidden.test.js
@@ -12,6 +12,8 @@ const testValue = {
 
 describe('mixin-hidden.js', () => {
   let Constructor
+  // 防止测试过程中注入报错
+  delete renderFormItem.inject
   beforeEach(() => {
     Constructor = Vue.extend(renderFormItem)
   })


### PR DESCRIPTION
## Why
源码中几个地方需要依赖到父组件的方法，但是获取父实例的时候需要循环向上遍历。

![image](https://user-images.githubusercontent.com/20502762/86703977-ffcba000-c046-11ea-9aac-391ad5e9c823.png)

如果用户注册的 `component name` 不正确就会找不到该父实例 (ps: 已踩坑).

## How
1. `ElFormRenderer` 实例把自己作为属性 `provide`
2. `render-form-item` `inject` 声明 `elFormRenderer` 以及 `elForm` 属性避免向上遍历

## Test

1. setOptions 测试通过 🎉

![set-options](https://user-images.githubusercontent.com/20502762/86704415-6ea8f900-c047-11ea-8ecf-ce8d5b776d7b.png)

2. validateField 方法测试通过 🎉

![validateField](https://user-images.githubusercontent.com/20502762/86704457-7b2d5180-c047-11ea-8d74-3b3d2912ad6e.jpeg)

