### PR TITLE
feat: checkbox label顺序调整

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -51,7 +51,13 @@ export default {
           rules: [
             { type: 'date', required: true, message: 'miss date', trigger: 'change' }
           ]
-        }, {
+        },
+        {
+          type: "checkbox",
+          id: "checkbox",
+          label: <span>checkbox<i class="el-icon-edit"></i></span>,
+        },
+        {
           type: 'switch',
           id: 'delivery',
           label: 'delivery'

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -2,13 +2,17 @@
   <el-form-item
     v-show="_show"
     :prop="prop"
-    :label="typeof data.label === 'string' ? data.label : ''"
+    :label="
+      typeof data.label === 'string' && data.type !== 'checkbox'
+        ? data.label
+        : ''
+    "
     :rules="!readonly && Array.isArray(data.rules) ? data.rules : []"
     v-bind="data.attrs"
     class="render-form-item"
   >
     <v-node
-      v-if="typeof data.label !== 'string'"
+      v-if="typeof data.label !== 'string' && data.type !== 'checkbox'"
       slot="label"
       :content="data.label"
     />
@@ -55,6 +59,12 @@
           :label="'value' in opt ? opt.value : opt.label"
           >{{ opt.label }}</el-radio
         >
+      </template>
+      <template v-if="data.type === 'checkbox'">
+        <template v-if="typeof data.label === 'string'">
+          {{ data.label }}
+        </template>
+        <v-node v-else slot="label" :content="data.label" />
       </template>
     </custom-component>
   </el-form-item>


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
Fix #196 

## How
1. 判断type为checkbox时，原有label不渲染，放到el-checkbox里渲染
```html
<template>
  <!-- type===checkbox 不渲染  -->
  <el-form-item :label="
      typeof data.label === 'string' && data.type !== 'checkbox'
        ? data.label
        : ''
    ">
    <v-node v-if="typeof data.label !== 'string' && data.type !== 'checkbox'" />
    <custom-component>
      <!-- type===checkbox 内部渲染label  -->
      <template v-if="data.type === 'checkbox'">
        <template v-if="typeof data.label === 'string'">
          {{ data.label }}
        </template>
        <v-node v-else slot="label" :content="data.label" />
      </template>
    </custom-component>
  </el-form-item>
</template>
```

## 效果

![1](https://user-images.githubusercontent.com/19562649/94097744-ac087000-fe59-11ea-8eac-841a2caa4817.gif)



