### PR TITLE
feat: type为el-checkbox-group的options提供value属性

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -61,11 +61,14 @@ export default {
           label: 'type',
           default: [],
           options: [{
-            label: 'typeA'
+            label: 'typeA',
+            value: 'A'
           }, {
-            label: 'typeB'
+            label: 'typeB',
+            value:'B'
           }, {
-            label: 'typeC'
+            label: 'typeC',
+            value: 'C'
           }],
           rules: [
             { type: 'array', required: true, message: 'miss type', trigger: 'change' }

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -43,9 +43,12 @@
         <!-- TODO: 支持 el-checkbox-button 变体 -->
         <el-checkbox
           v-else-if="data.type === 'checkbox-group'"
-          :key="opt.label"
+          :key="opt.value"
           v-bind="opt"
-        />
+          :label="'value' in opt ? opt.value : opt.label"
+        >
+          {{ opt.label }}
+        </el-checkbox>
         <!-- WARNING: radio 用 label 属性来表示 value 的含义 -->
         <!-- FYI: radio 的 value 属性可以在没有 radio-group 时用来关联到同一个 v-model -->
         <el-radio


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
fix #170 

## How

1. 类似el-radio-group的做法
![image](https://user-images.githubusercontent.com/19562649/94108538-13cab500-fe72-11ea-9205-1f4df1e49181.png)
```html
<el-checkbox
     :key="opt.value"
      v-bind="opt"
     :label="'value' in opt ? opt.value : opt.label"
>
     {{ opt.label }}
</el-checkbox>
```
