### PR TITLE
fix: form和content的key没有对应上，导致find取不到item对象

### DIFF
--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -43,6 +43,7 @@ export function transformOutputValue(value, content) {
   const newVal = {}
   Object.keys(value).forEach(id => {
     const item = content.find(item => item.id === id)
+    if (!item) return
     if (item.type !== 'group') {
       if (item.outputFormat) {
         const v = item.outputFormat(value[id])

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -151,11 +151,11 @@ describe('transformOutputValue', () => {
         items: [
           {
             id: 'c',
-            outputFormat: v => v - 1,
+            outputFormat: c => c - 1,
           },
           {
             id: 'd',
-            outputFormat: v => ({e: v + 1}),
+            outputFormat: d => ({e: d + 1}),
           },
         ],
       },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -129,6 +129,39 @@ describe('transformOutputValue', () => {
     ]
     expect(transformOutputValue(v, content)).toEqual(v)
   })
+
+  test('form oldV和content的key没有对应上的情况', () => {
+    const oldV = {
+      a: 1,
+      b: {
+        c: 2,
+        d: 3,
+      },
+    }
+    const newV = {
+      b: {
+        c: 1,
+        e: 4,
+      },
+    }
+    const content = [
+      {
+        id: 'b',
+        type: 'group',
+        items: [
+          {
+            id: 'c',
+            outputFormat: v => v - 1,
+          },
+          {
+            id: 'd',
+            outputFormat: v => ({e: v + 1}),
+          },
+        ],
+      },
+    ]
+    expect(transformOutputValue(oldV, content)).toEqual(newV)
+  })
 })
 
 describe('transformInputValue', () => {


### PR DESCRIPTION
## Why

业务场景:  动态改变content，从而改变form的排版。 

## How
 [online demo](https://codesandbox.io/s/el-form-renderer-pxo01?file=/src/App.vue)

1.  打开控制台
2. 执行setContent
3. 执行resetFields
4. 控制台提示TypeError: Cannot read property 'type' of undefined

![image](https://user-images.githubusercontent.com/20294811/100621333-836d8c80-335a-11eb-9cdf-a1718c05f5f1.png)


## Test
Show your test case

you'd better show `before` and `after` 

## Docs
It there requires a change to the documentation？
