### PR TITLE
fix: select option 支持 object

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -30,12 +30,21 @@ export default {
           type: 'select',
           id: 'region',
           label: 'area',
+          el: {
+            valueKey: 'id',
+          },
           options: [{
             label: 'area1',
-            value: 'shanghai'
+            value: {
+              id: 'shanghai',
+              name: 'shanghai'
+            }
           }, {
             label: 'area2',
-            value: 'beijing'
+            value: {
+              id: 'beijing',
+              name: 'beijing'
+            }
           }],
           rules: [
             { required: true, message: 'miss area', trigger: 'change' }

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -35,10 +35,10 @@
       :disabled="disabled || componentProps.disabled || readonly"
       v-on="listeners"
     >
-      <template v-for="opt in options">
+      <template v-for="(opt, index) in options">
         <el-option
           v-if="data.type === 'select'"
-          :key="opt.value"
+          :key="optionKey(opt) || index"
           v-bind="opt"
         />
         <!-- TODO: 支持 el-checkbox-button 变体 -->
@@ -246,6 +246,17 @@ export default {
       this.$nextTick(() => {
         this.elForm && this.elForm.validateField(id)
       })
+    },
+    optionKey(opt) {
+      if (opt.value instanceof Object) {
+        if (!this.data.el || !this.data.el.valueKey) {
+          return
+        }
+
+        return opt.value[this.data.el.valueKey]
+      } else {
+        return opt.value
+      }
     },
   },
 }


### PR DESCRIPTION
## Why

如果 `select` 的 `options` 的 `value` 提供一个 `object`，会报错，原因：重复的 `key`

![image](https://user-images.githubusercontent.com/21327913/101737252-94a75d80-3aff-11eb-99c6-31af6230e06c.png)

## How

`el-select` 支持 `value` 是一个对象，并且可以指派一个 `valueKey`作为标记

![image](https://user-images.githubusercontent.com/21327913/101737609-14352c80-3b00-11eb-8d6c-cac47692b5b9.png)

那么组件可以利用之 —— 让 `key` 可以自行判断应该使用什么值

## Test

看下面 `netlify`，不可描述
