### PR TITLE
feat: el-select 时 remote.request 能获取输入的 query

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -13,16 +13,15 @@ export default {
     let getRemoteUrl = (query) => 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-form-renderer?q=remote&input=' + query
     return {
       content: [
-        // 只需要设置 url，即可远程配置 options
         {
           type: 'select',
           id: 'select',
-          label: 'select',
+          label: 'remote-by-url',
           remote: {
-            url: ''
+            url: '' // 通过设置 url，获取远程配置 options
           },
           el: {
-            placeholder: '请输入，会发请求',
+            placeholder: '请输入会发请求,',
             filterable: true,
             remote: true,
             remoteMethod: query => {
@@ -30,6 +29,24 @@ export default {
             }
           }
         },
+        {
+          type: 'select',
+          id: 'remote-by-request',
+          label: 'remote-by-request',
+          remote: {
+            // filterable 与 remote 为 true 时，会传入 query 参数
+            request(query) {
+              console.log(query)
+            }
+          },
+          el: {
+            width: '200px',
+            placeholder: '请输入，控制台会打印输入值',
+            filterable: true,
+            remote: true,
+          }
+        },
+
         // 可以自定义 request 方法，做各种操作
         {
           type: 'radio-group',

--- a/src/components/render-form-item.vue
+++ b/src/components/render-form-item.vue
@@ -34,6 +34,9 @@
       :value="itemValue"
       :disabled="disabled || componentProps.disabled || readonly"
       :loading="loading"
+      :remote-method="
+        data.remoteMethod || componentProps.remoteMethod || remoteMethod
+      "
       v-on="listeners"
     >
       <template v-for="(opt, index) in options">
@@ -242,7 +245,7 @@ export default {
         return opt.value
       }
     },
-    makingRequest(remoteConfig) {
+    makingRequest(remoteConfig, query) {
       const isOptionsCase =
         ['select', 'checkbox-group', 'radio-group'].indexOf(this.data.type) > -1
       const {
@@ -270,7 +273,7 @@ export default {
 
       this.loading = true
 
-      Promise.resolve(request())
+      Promise.resolve(request(query))
         .then(onResponse, onError)
         .then(resp => {
           if (isOptionsCase) {
@@ -282,6 +285,15 @@ export default {
 
           this.loading = false
         })
+    },
+    remoteMethod(query) {
+      if (
+        _get(this.data, 'type') === 'select' &&
+        _get(this.data, 'el.filterable') &&
+        _get(this.data, 'el.remote')
+      ) {
+        this.makingRequest(this.data.remote, query)
+      }
     },
   },
 }


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
适用以下场景：el-select 数据动态获取，并支持输入时模糊查询。

为了更方便！

改动前：
```js
          {
            type: 'select',
            el: {
              filterable: true,
              remote: true,
              remoteMethod: query => {
                this.tableProps.form.find(
                  item => item.id == 'pocTenantId'
                ).remote.url = getSelectUrl(query)
              },
            },
            remote: {
              url: getSelectUrl(''),
            }
          },

```

改动后：
```
        {
          type: 'select',
          remote: {
            // filterable 与 remote 为 true 时，会传入 query 参数
            request(query) {
              console.log(query)
            }
          },
          el: {
            filterable: true,
            remote: true,
          }
        },
```

## Test
![image](https://user-images.githubusercontent.com/9384365/129352835-1fc47129-19b5-47a5-a3b9-ce719b10f651.png)


## Docs
yes
