### PR TITLE
feat: getFormValue 可以开启 strict mode

### DIFF
--- a/cypress/integration/remote.spec.js
+++ b/cypress/integration/remote.spec.js
@@ -6,7 +6,8 @@ describe('测试 remote 示例', function() {
     cy.$goto('remote')
   })
   it('测试所有 remote 配置', function() {
-    cy.$getFormItemInput('select')
+    cy.get('.el-select')
+      .first()
       .click()
       .type('input')
     cy.contains('area1').click()

--- a/docs/get-form-value.md
+++ b/docs/get-form-value.md
@@ -1,4 +1,5 @@
-get the form value
+默认情况下，通过 updateForm 设置的所有值都会输出。
+如果只想输出根据 content 设置的表单项的值，可传入 {strict: true}
 
 ```vue
 <template>

--- a/docs/update-form.md
+++ b/docs/update-form.md
@@ -1,10 +1,16 @@
+默认情况下，updateForm 来者不拒，不在表单设置内的值，也可以存储进去
+
 ```vue
 <template>
   <div class="update-form">
     <el-form-renderer :content="content" inline ref="formRender">
       <el-button @click="setValue">updateForm()</el-button>
-      <el-button type="primary" @click="getValue">log getFormValue()</el-button>
+      <div>
+	    <el-button type="primary" @click="getValue(false)">log getFormValue()</el-button>
+	    <el-button type="primary" @click="getValue(true)">log getFormValue({strict: true})</el-button>
+      </div>
     </el-form-renderer>
+    <pre>{{ value }}</pre>
   </div>
 </template>
 
@@ -13,6 +19,7 @@
     name: 'update-form',
     data() {
       return {
+        value: {},
         content: [
           {
             id: 'name',
@@ -41,14 +48,16 @@
       }
     },
     methods: {
-      getValue () {
-        const value = this.$refs.formRender.getFormValue()
-        console.log(value)
+      getValue (strict) {
+        const value = this.$refs.formRender.getFormValue({strict})
+		this.value = value
       },
       setValue () {
         this.$refs.formRender.updateForm({
           name: 'alvin',
-          newKey: 'newValue',
+          area: 'shanghai',
+		  // 设置冗余字段
+          extraKey: 'extraValue',
         })
       }
     }

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -188,6 +188,8 @@ export default {
       this.value = {...this.value, [id]: value}
     },
     /**
+     * 当 strict 为 true 时，只返回设置的表单项的值, 过滤掉冗余字段, 更多请看 update-form 示例
+     * @param {{strict: Boolean}} 默认 false
      * @return {object} key is item's id, value is item's value
      * @public
      */

--- a/src/el-form-renderer.vue
+++ b/src/el-form-renderer.vue
@@ -191,8 +191,8 @@ export default {
      * @return {object} key is item's id, value is item's value
      * @public
      */
-    getFormValue() {
-      return transformOutputValue(this.value, this.innerContent)
+    getFormValue({strict = false} = {}) {
+      return transformOutputValue(this.value, this.innerContent, {strict})
     },
     /**
      * update form values

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -37,10 +37,13 @@ export function mergeValue(oldV, newV, content) {
  * 根据 content 中的 outputFormat 来处理 value；
  * 如果 outputFormat 处理后的值是对象类型，会覆盖（Object.assign）到 value 上
  */
-export function transformOutputValue(value, content) {
-  const newVal = {...value}
+export function transformOutputValue(value, content, {strict = false} = {}) {
+  const newVal = strict ? {} : {...value}
+
   Object.keys(value).forEach(id => {
-    const item = content.find(item => item.id === id) || {}
+    const item = content.find(item => item.id === id)
+    if (!item) return
+
     if (item.type !== 'group') {
       if (item.outputFormat) {
         const v = item.outputFormat(value[id])
@@ -51,7 +54,7 @@ export function transformOutputValue(value, content) {
         newVal[id] = value[id]
       }
     } else {
-      newVal[id] = transformOutputValue(value[id], item.items)
+      newVal[id] = transformOutputValue(value[id], item.items, {strict})
     }
   })
   return newVal

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -133,21 +133,6 @@ describe('transformOutputValue', () => {
   })
 
   test('oldV 和 content 的 key 没有对应上的情况', () => {
-    const oldV = {
-      a: 1,
-      b: {
-        c: 2,
-        d: 3,
-      },
-    }
-    const newV = {
-      a: 1, // 冗余字段
-      b: {
-        c: 1,
-        e: 4,
-        d: 3, // 冗余字段
-      },
-    }
     const content = [
       {
         id: 'b',
@@ -164,7 +149,32 @@ describe('transformOutputValue', () => {
         ],
       },
     ]
-    expect(transformOutputValue(oldV, content)).toEqual(newV)
+    const input = {
+      a: 1,
+      b: {
+        c: 2,
+        d: 3,
+      },
+    }
+    const outputStrict = {
+      b: {
+        c: 1,
+        e: 4,
+      },
+    }
+    const outputNonstrict = {
+      b: {
+        c: 1,
+        e: 4,
+        d: 3, // 冗余字段
+      },
+      a: 1, // 冗余字段
+    }
+
+    expect(transformOutputValue(input, content, {strict: true})).toEqual(
+      outputStrict,
+    )
+    expect(transformOutputValue(input, content)).toEqual(outputNonstrict)
   })
 })
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
前面对于 updateForm 的更新，使得表单可以存储冗余字段，但在某些情况下，会导致 getFormValue 得到的值不理想。如下所示：

同一份数据，分成N个表单显示
![image](https://user-images.githubusercontent.com/9384365/130032964-5f5b0e7b-0d61-4b0f-bbbd-78d85760b25d.png)

最终聚合N个表单的数据
![image](https://user-images.githubusercontent.com/9384365/130032653-f634c587-a5f6-49b3-a8d9-4a7fc8fe5894.png)

如果没有 strict 模式，后面的表单会覆盖掉前面表单的值，使得程序出现 bug。

## How
添加 {strict} 选项。
考虑（近期的代码）兼容性，默认为 false。

但如果之前有人拆分表单再做聚合的，默认 false 对他们来说是破坏性的？🤔
考虑这种概率比较小，就按这样设置吧

## Test
yes, all pass

## Docs
yes
